### PR TITLE
feat(AbstractStorage): return item found type

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -2,4 +2,4 @@
 commitizen:
   name: cz_conventional_commits
   tag_format: $version
-  version: 2.0.0
+  version: 3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 3.0.0 (2025-01-18)
+
+### BREAKING CHANGE
+
+- AbstractStorage::getByKey now returns ItemFound instead of Item.
+
+### Feat
+
+- **AbstractStorage**: return item found type
+
 ## 2.0.0 (2023-07-03)
 
 ### BREAKING CHANGE

--- a/src/AbstractStorage.php
+++ b/src/AbstractStorage.php
@@ -94,9 +94,10 @@ abstract class AbstractStorage
     /**
      * Retrieves an item by key.
      */
-    public function getByKey(ItemKey $key): Item|ItemNotFound
+    public function getByKey(ItemKey $key): ItemFound|ItemNotFound
     {
-        return $this->map[$this->keyMap[(string) $key] ?? $key] ?? new ItemNotFound();
+        $result = $this->map[$this->keyMap[(string) $key] ?? $key] ?? new ItemNotFound();
+        return $result instanceof ItemNotFound ? $result : new ItemFound($result);
     }
 
     /**

--- a/src/Item.php
+++ b/src/Item.php
@@ -9,7 +9,7 @@ namespace Phpolar\Phpolar\Storage;
  */
 final class Item
 {
-    public function __construct(private mixed $item)
+    public function __construct(private readonly mixed $item)
     {
     }
 

--- a/src/ItemFound.php
+++ b/src/ItemFound.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpolar\Phpolar\Storage;
+
+use RuntimeException;
+
+/**
+ * Represents the scenario when an item is found.
+ */
+final class ItemFound
+{
+    public function __construct(private readonly Item $item) {}
+
+    public function bind(): mixed
+    {
+        return $this->item->bind();
+    }
+}

--- a/src/ItemNotFound.php
+++ b/src/ItemNotFound.php
@@ -12,8 +12,8 @@ use RuntimeException;
 final class ItemNotFound
 {
     /**
-     * This method exists to unit this type
-     * with the Item type.
+     * This method exists to unite this type
+     * with the ItemFound type.
      *
      * An exception will be thrown if this method is called.
      * @throws RuntimeException

--- a/tests/unit/AbstractStorageTest.php
+++ b/tests/unit/AbstractStorageTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 #[CoversClass(AbstractStorage::class)]
 #[CoversClass(Item::class)]
+#[CoversClass(ItemFound::class)]
 #[CoversClass(ItemNotFound::class)]
 #[CoversClass(KeyNotFound::class)]
 final class AbstractStorageTest extends TestCase
@@ -41,7 +42,7 @@ final class AbstractStorageTest extends TestCase
         $sut = $this->getStorageStub();
         $sut->storeByKey($givenKey, new Item($givenItem));
         $result = $sut->getByKey($givenKey);
-        $this->assertInstanceOf(Item::class, $result);
+        $this->assertInstanceOf(ItemFound::class, $result);
         $storedItem = $result->bind();
         $this->assertObjectEquals($givenItem, $storedItem);
     }
@@ -50,9 +51,6 @@ final class AbstractStorageTest extends TestCase
     public function test1b()
     {
         $givenKey = new ItemKey(uniqid());
-        $givenItem = new FakeModel();
-        $givenItem->title = "TITLE";
-        $givenItem->myInput = "something";
         $sut = $this->getStorageStub();
         $result = $sut->getByKey($givenKey);
         $this->assertInstanceOf(ItemNotFound::class, $result);
@@ -101,7 +99,7 @@ final class AbstractStorageTest extends TestCase
         $sut = $this->getStorageStub();
         $sut->storeByKey($givenKey, new Item($givenItem));
         $result = $sut->getByKey($givenKey);
-        $this->assertInstanceOf(Item::class, $result);
+        $this->assertInstanceOf(ItemFound::class, $result);
         $storedItem = $result->bind();
         $this->assertObjectEquals($givenItem, $storedItem);
     }
@@ -116,7 +114,7 @@ final class AbstractStorageTest extends TestCase
         $sut = $this->getStorageStub();
         $sut->storeByKey($givenKey, new Item($givenItem));
         $result = $sut->getByKey($givenKey);
-        $this->assertInstanceOf(Item::class, $result);
+        $this->assertInstanceOf(ItemFound::class, $result);
         $storedItem = $result->bind();
         $this->assertObjectEquals($givenItem, $storedItem);
         $sut->removeByKey($givenKey);


### PR DESCRIPTION
Return ItemFound instead of Item in AbstractStorage: :getByKey. The ItemNotFound and ItemFound types define all possible result states.

BREAKING CHANGE: AbstractStorage::getByKey now returns ItemFound instead of Item.