### PR TITLE
feat: add storage context interfaces

### DIFF
--- a/phpdoc.xml
+++ b/phpdoc.xml
@@ -9,7 +9,7 @@
         <output>/docs</output>
         <cache>.phpdoc/build/cache</cache>
     </paths>
-    <version number="1.0.0">
+    <version number="5.0.0">
         <api format="php">
             <source dsn="./src"></source>
           <default-package-name>Phpolar</default-package-name>

--- a/src/AbstractStorage.php
+++ b/src/AbstractStorage.php
@@ -20,7 +20,7 @@ abstract class AbstractStorage implements StorageContext, Countable
      */
     private array $map = [];
 
-    public function __construct(private readonly LifeCycleHooks $hooks)
+    public function __construct(private readonly InitHook & DestroyHook $hooks)
     {
         $this->hooks->onInit();
     }

--- a/src/Closable.php
+++ b/src/Closable.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Phpolar\Storage;
+
+/**
+ * Provides resource closing functionality.
+ */
+interface Closable
+{
+    /**
+     * Cleanup resources.
+     */
+    public function close(): void;
+}

--- a/src/DestroyHook.php
+++ b/src/DestroyHook.php
@@ -4,16 +4,11 @@ namespace Phpolar\Storage;
 
 /**
  * Encapsulates hooks that will
- * be called at life cylce intervals
+ * be called during a class's
+ * destructure phase
  */
-interface LifeCycleHooks
+interface DestroyHook
 {
-    /**
-     * Calls the attached hooks when the storage
-     * is initialized
-     */
-    public function onInit(): void;
-
     /**
      * Calls the attached hooks when the storage
      * is destroyed

--- a/src/InitHook.php
+++ b/src/InitHook.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Phpolar\Storage;
+
+/**
+ * Encapsulates hooks that will
+ * be called when a class is
+ * constructed.
+ */
+interface InitHook
+{
+    /**
+     * Calls the attached hooks when the class
+     * is initialized
+     */
+    public function onInit(): void;
+}

--- a/src/Loadable.php
+++ b/src/Loadable.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Phpolar\Storage;
+
+/**
+ * Supports loading data from the storage context.
+ */
+interface Loadable
+{
+    /**
+     * Load data from the storage context into memory.
+     */
+    public function load(): void;
+}

--- a/src/Persistable.php
+++ b/src/Persistable.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Phpolar\Storage;
+
+/**
+ * Supports persisting data into a storage context.
+ */
+interface Persistable
+{
+    /**
+     * Persist data into a storage context.
+     */
+    public function persist(): void;
+}

--- a/tests/unit/AbstractStorageTest.php
+++ b/tests/unit/AbstractStorageTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phpolar\Storage;
 
-use Phpolar\Storage\LifeCycleHooks;
 use Phpolar\Storage\Tests\Fakes\FakeModel;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
@@ -18,7 +17,7 @@ final class AbstractStorageTest extends TestCase
 {
     protected function getStorageStub(): AbstractStorage
     {
-        $lifeCycleHooksStub = $this->createStub(LifeCycleHooks::class);
+        $lifeCycleHooksStub = $this->createMockForIntersectionOfInterfaces([DestroyHook::class, InitHook::class]);
         return new class($lifeCycleHooksStub) extends AbstractStorage {};
     }
     #[TestDox("Shall allow for retrieving an item by key")]
@@ -357,7 +356,7 @@ final class AbstractStorageTest extends TestCase
     #[TestDox("Shall call onInit of the given life cycle hooks when created")]
     public function testg()
     {
-        $spy = $this->createMock(LifeCycleHooks::class);
+        $spy = $this->createMockForIntersectionOfInterfaces([InitHook::class, DestroyHook::class]);
 
         $spy->expects($this->once())->method("onInit");
 
@@ -367,7 +366,7 @@ final class AbstractStorageTest extends TestCase
     #[TestDox("Shall call onDestroy of the given life cycle hooks when destroyed")]
     public function testh()
     {
-        $spy = $this->createMock(LifeCycleHooks::class);
+        $spy = $this->createMockForIntersectionOfInterfaces([InitHook::class, DestroyHook::class]);
 
         $spy->expects($this->once())->method("onDestroy");
 
@@ -376,6 +375,6 @@ final class AbstractStorageTest extends TestCase
         /**
          * call destructor
          */
-        $a = null;
+        unset($a);
     }
 }


### PR DESCRIPTION
BREAKING CHANGE: LifeCycleHooks has been split into DestroyHook and InitHook interfaces.